### PR TITLE
[Bug Fix]Predicate caster before update death beam

### DIFF
--- a/src/main/java/com/Polarice3/goety_cataclysm/common/entities/projectiles/DeathLaserBeam.java
+++ b/src/main/java/com/Polarice3/goety_cataclysm/common/entities/projectiles/DeathLaserBeam.java
@@ -123,7 +123,7 @@ public class DeathLaserBeam extends Entity {
         if (!this.level().isClientSide) {
             if (this.caster instanceof ProwlerServant) {
                 this.updateWithProwler();
-            } else {
+            } else if(this.caster != null) {
                 this.updateWithCaster();
             }
         }


### PR DESCRIPTION
Predicate caster before update death beam for it can be null sometimes and which causes crash